### PR TITLE
feat: sort tabs by MRU by default

### DIFF
--- a/extension/alfred.js
+++ b/extension/alfred.js
@@ -303,12 +303,14 @@ const Background = function() {
 
   /**
    * Handle "all-tabs" command.
-   * @return {Promise} - Resolves to array of Tab objects for all tabs.
+   * @return {Promise} - Resolves to array of Tab objects for all tabs sorted
+   * by most recently used.
    */
   self.allTabs = () => {
-    return browser.tabs.query({}).then(tabs => {
-      return tabs.map(t => Tab(t));
-    });
+    return browser.tabs.query({}).then(tabs => tabs
+      .sort((a, b) => (b?.lastAccessed ?? 0) - (a?.lastAccessed ?? 0))
+      .map(t => Tab(t))
+    );
   };
 
   /**


### PR DESCRIPTION
👋 ,

Currently the tabs are returned in the order they appear in the firefox
window (the default order).
I think this order rarely makes sense, and making it MRU could be more
useful in most situations.

This changes returns the list of tabs sorted by the `lastAccessed`
timestamp (see the [docs](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Browser_support_for_JavaScript_APIs#tabs)).

Fixes #12