### PR TITLE
remove promise chain in sendNative -- postMessage does not return anything

### DIFF
--- a/extension/alfred.js
+++ b/extension/alfred.js
@@ -271,14 +271,8 @@ const Background = function() {
    */
   self.sendNative = msg => {
     if (self.nativePort) {
-      self.nativePort.postMessage(msg)
-        .then(resp => {
-          console.log(`sent:`, msg);
-          console.log(`response:`, resp);
-        })
-        .catch(err => {
-          console.error(`send error: ${err.message}`);
-      });
+      self.nativePort.postMessage(msg);
+      console.log(`sent:`, msg);
     }
   };
 


### PR DESCRIPTION
During normal use of the extension, I noticed error-like output in the browser console (Cmd-Shift-J)

After poking around with the debugger and reading up on native messaging, I've concluded that postMessage does not return anything (and in particular, not a promise that can chain `then` and `catch`).

Without this change, each call from `receiveNative` to `sendNative` posts a message, raises a TypeError, which ends up calling `sendNative` again via `sendError`

With this change, the errors are eliminated, and the sent message is logged.

### Before

<img width="840" alt="image" src="https://user-images.githubusercontent.com/60824/110224786-86b17080-7e93-11eb-8d67-380c0b1acc2e.png">

### After

<img width="840" alt="image" src="https://user-images.githubusercontent.com/60824/110224793-9466f600-7e93-11eb-94cb-9665df229ac9.png">
